### PR TITLE
Update rcic_generate_stimuli.m

### DIFF
--- a/rcic_generate_stimuli.m
+++ b/rcic_generate_stimuli.m
@@ -115,9 +115,9 @@ end
 fprintf('Loading base face image %s...', cfg.bf);
 
 %load base face
-img = double(imread(cfg.bf));
+img = imread(cfg.bf);
 
-if (ndims(img) > 2)
+if (ismatrix(img) ==0)
     %make grayscale if necessary
     img = rgb2gray(img);
 end
@@ -128,7 +128,8 @@ if (cfg.blur)
     fprintf('blurred...');
 end
 
-%scale to range 0-1
+%change to double and scale to range 0-1
+img = double(img);
 img = (img - min(img(:))) / (max(img(:)) - min(img(:)));
 fprintf('normalized...');
 


### PR DESCRIPTION
Using the original file, it can only generate picture with random noise, no face in there, as shown in follows. It took me quite some time to find the bug during converting the data type of images. 

![ym_ym_1_001_0](https://cloud.githubusercontent.com/assets/24452296/22010248/024487f4-dcc3-11e6-8355-d11fe282e57c.png)

imshow function will read 0-255 in unit8 (data type) as true color channel or grayscale, while read 0-1 in double (data type) as grayscale. rgb2gray function can operate on both unit8 and double.  And yet when you use rgb2gray converting a read-in image with rgb in double to grayscale,  you will only get a matrix of 1, which will be a total white picture when 'imshow'ed.  And this matrix of 1 becomes the "base face"  on which the random noises are added. 

So, during scaling to 0-1, conversion from rgb to grayscale should happen first, then followed by conversion to double.